### PR TITLE
Allow microsecond precision tests

### DIFF
--- a/sqlalchemy_ibmi/requirements.py
+++ b/sqlalchemy_ibmi/requirements.py
@@ -29,20 +29,6 @@ class Requirements(SuiteRequirements):
         return exclusions.closed()
 
     @property
-    def datetime_microseconds(self):
-        """target dialect supports representation of Python
-        datetime.datetime() with microsecond objects."""
-
-        return exclusions.closed()
-
-    @property
-    def time_microseconds(self):
-        """target dialect supports representation of Python
-        datetime.time() with microsecond objects."""
-
-        return exclusions.closed()
-
-    @property
     def unbounded_varchar(self):
         """Target database must support VARCHAR with no length"""
 

--- a/sqlalchemy_ibmi/requirements.py
+++ b/sqlalchemy_ibmi/requirements.py
@@ -19,6 +19,13 @@ class Requirements(SuiteRequirements):
         return exclusions.closed()
 
     @property
+    def time_microseconds(self):
+        """target dialect supports representation of Python
+        datetime.time() with microsecond objects."""
+
+        return exclusions.closed()
+
+    @property
     def unbounded_varchar(self):
         """Target database must support VARCHAR with no length"""
 

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -19,6 +19,8 @@ from sqlalchemy.testing.suite \
     import UnicodeTextTest as _UnicodeTextTest
 from sqlalchemy.testing.suite \
     import UnicodeVarcharTest as _UnicodeVarcharTest
+from sqlalchemy.testing.suite \
+    import TimeMicrosecondsTest as _TimeMicrosecondsTest
 
 
 # removed constraint that used same columns with different name as it caused
@@ -210,4 +212,11 @@ class UnicodeVarcharTest(_UnicodeVarcharTest):
         return
 
     def test_literal_non_ascii(self):
+        return
+
+
+class TimeMicrosecondsTest(_TimeMicrosecondsTest):
+
+    # test skipped due to incompatibility with IBM i for sub-second time.
+    def test_round_trip(self):
         return

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -19,8 +19,6 @@ from sqlalchemy.testing.suite \
     import UnicodeTextTest as _UnicodeTextTest
 from sqlalchemy.testing.suite \
     import UnicodeVarcharTest as _UnicodeVarcharTest
-from sqlalchemy.testing.suite \
-    import TimeMicrosecondsTest as _TimeMicrosecondsTest
 
 
 # removed constraint that used same columns with different name as it caused
@@ -212,11 +210,4 @@ class UnicodeVarcharTest(_UnicodeVarcharTest):
         return
 
     def test_literal_non_ascii(self):
-        return
-
-
-class TimeMicrosecondsTest(_TimeMicrosecondsTest):
-
-    # test skipped due to incompatibility with IBM i for sub-second time.
-    def test_round_trip(self):
         return


### PR DESCRIPTION
IBM i supports microsecond precision timestamps.

Fixes: #48