### PR TITLE
Set up CI connecting to remote IBM i system

### DIFF
--- a/.github/scripts/runtests.py
+++ b/.github/scripts/runtests.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+
+import os
+import pyodbc
+import pytest
+
+host = os.environ['IBMI_HOSTNAME']
+uid = os.environ['IBMI_USERNAME']
+pwd = os.environ['IBMI_PASSWORD']
+
+URI = "ibmi://{uid}:{pwd}@{host}/".format(
+    host=host,
+    uid=uid,
+    pwd=pwd,
+)
+
+# Maybe can use a different schema in the future?
+schema = uid
+
+# allocate an object to serialize access to the test schemas
+# without this, the tests will step on each other
+# we can't use different schemas because some of the tests use the
+# hard-coded test_schema schema
+print("Connecting to the remote system", flush=True)
+conn = pyodbc.connect(
+    "Driver=IBM i Access ODBC Driver",
+    system=host,
+    user=uid,
+    password=pwd,
+)
+cur = conn.cursor()
+
+print("Attempting to lock the mutex", flush=True)
+lock = "ALCOBJ OBJ(({schema}/CI_MUTEX *DTAARA *EXCL)) WAIT(30)".format(schema=schema)
+while True:
+    try:
+        cur.execute("CALL QSYS2.QCMDEXC(?)", [lock])
+        break
+    except pyodbc.Error as e:
+        if 'CPF1002' not in e.args[1]:
+            raise e
+
+print("Mutex locked, running tests", flush=True)
+rc = pytest.main(["--dburi", URI])
+
+print("Unlocking mutex", flush=True)
+unlock = "DLCOBJ OBJ(({schema}/CI_MUTEX *DTAARA *EXCL))".format(schema=schema)
+cur.execute("CALL QSYS2.QCMDEXC(?)", [unlock])
+
+exit(rc)

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 4
+      fail-fast: false
       matrix:
         python-version: [3.5, 3.6, 3.7]
 
@@ -19,6 +20,22 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install unixodbc on Linux
       run: sudo apt-get install unixodbc unixodbc-dev
+    - name: Load Driver from Cache
+      id: load-driver-cache
+      uses: actions/cache@v1
+      with:
+        path: installer
+        key: ibm-iaccess-1.1.0.13
+    - name: Download Driver to Cache
+      if: steps.load-driver-cache.outputs.cache-hit != 'true'
+      run: |
+        mkdir installer
+        wget --no-verbose https://public.dhe.ibm.com/software/ibmi/products/odbc/ibm-iaccess-1.1.0.13-1.0.amd64.deb.gpg -O installer/ibm-iaccess-1.1.0.13-1.0.amd64.deb.gpg
+        gpg --quiet --batch --yes --decrypt --passphrase="$PASSWORD" --output installer/ibm-iaccess-1.1.0.13-1.0.amd64.deb installer/ibm-iaccess-1.1.0.13-1.0.amd64.deb.gpg
+      env:
+        PASSWORD: ${{ secrets.GPG_PASSWORD }}
+    - name: Install driver
+      run: sudo dpkg -i installer/ibm-iaccess-1.1.0.13-1.0.amd64.deb
     - name: Install dependencies
       run: |
         pip install poetry
@@ -31,8 +48,11 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-#    - name: Test with pytest
-#      run: |
-#        pip install pytest
-#        pytest
-      
+    - name: Test with pytest
+      run: |
+        pip install 'pytest<5.4'
+        .github/scripts/runtests.py
+      env:
+        IBMI_HOSTNAME: ${{ secrets.IBMI_HOSTNAME }}
+        IBMI_USERNAME: ${{ secrets.IBMI_USERNAME }}
+        IBMI_PASSWORD: ${{ secrets.IBMI_PASSWORD }}


### PR DESCRIPTION
We fetch the encrypted IBM i ODBC driver installer from the download URL
and decrypt it, caching as needed. The decryption key, remote host,
username, and password are all secrets stored for GitHub Actions.

The tests need to use the same schemas, so we have to serialize access
while running the tests. While GitHub Actions supports a max-parallel
option, I don't belive that serializes the number of jobs that can be
running across all actions so if there were multiple PRs pushed at the
same time they could still step on each other.

Additionally, use pytest < 5.4 as 5.4 causes issues. #60 has been opened
to track this issue. For now, just use an earlier version of pytest.

Fixes #16