### PR TITLE
Implement IBM i specific _get_server_version_info

### DIFF
--- a/sqlalchemy_ibmi/base.py
+++ b/sqlalchemy_ibmi/base.py
@@ -755,7 +755,7 @@ class IBMiDb2Dialect(default.DefaultDialect):
     def _get_server_version_info(self, connection, allow_chars=True):
         if getattr(connection, "connection"):
             dbapi_con = connection.connection
-            version = dbapi_con.getinfo(self.dbapi.SQL_DBMS_VER).split('.')
+            version = [int(_) for _ in dbapi_con.getinfo(self.dbapi.SQL_DBMS_VER).split('.')]
             return tuple(version[0:2])
         return None
 

--- a/sqlalchemy_ibmi/base.py
+++ b/sqlalchemy_ibmi/base.py
@@ -753,12 +753,10 @@ class IBMiDb2Dialect(default.DefaultDialect):
         return vers
 
     def _get_server_version_info(self, connection, allow_chars=True):
-        if getattr(connection, "connection"):
-            dbapi_con = connection.connection
-            version = [int(_) for _ in dbapi_con.getinfo(self.dbapi.SQL_DBMS_VER).split('.')]
-            return tuple(version[0:2])
-        return None
-
+        dbapi_con = connection.connection
+        version = [int(_) for _ in
+                   dbapi_con.getinfo(self.dbapi.SQL_DBMS_VER).split('.')]
+        return tuple(version[0:2])
 
     def _get_default_schema_name(self, connection):
         """Return: current setting of the schema attribute"""

--- a/sqlalchemy_ibmi/base.py
+++ b/sqlalchemy_ibmi/base.py
@@ -753,15 +753,12 @@ class IBMiDb2Dialect(default.DefaultDialect):
         return vers
 
     def _get_server_version_info(self, connection, allow_chars=True):
-        # NOTE: this function is not reliable, particularly when
-        # freetds is in use.   Implement database-specific server version
-        # queries.
-        dbapi_con = connection.connection
-        version = []
-        r = re.compile(r"[.\-]")
-        for n in r.split(dbapi_con.getinfo(self.dbapi.SQL_DBMS_VER)):
-            version.append(int(n))
-        return tuple(version)
+        if getattr(connection, "connection"):
+            dbapi_con = connection.connection
+            version = dbapi_con.getinfo(self.dbapi.SQL_DBMS_VER).split('.')
+            return tuple(version[0:2])
+        return None
+
 
     def _get_default_schema_name(self, connection):
         """Return: current setting of the schema attribute"""


### PR DESCRIPTION
The method merged from PyODBCConnector did not handle the IBM i
server syntax and only keep the important major and minor version.

Fixes #67