### PR TITLE
Fix version and project badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Latest version released on PyPi](https://img.shields.io/pypi/v/sqlalchemy-ibmi.svg)](https://pypi.python.org/pypi/sqlalchemy-ibmi)
-[![](https://img.shields.io/pypi/pyversions/sqlalchemy-ibmi.svg)](https://pypi.org/project/itoolkit/)
+[![Latest version released on PyPi](https://img.shields.io/pypi/v/sqlalchemy-ibmi.svg)](https://pypi.org/project/sqlalchemy-ibmi)
+![Supported Python Version Badge](https://img.shields.io/pypi/pyversions/sqlalchemy-ibmi.svg)
 [![GitHub Actions status | sdras/awesome-actions](https://github.com/IBM/sqlalchemy-ibmi/workflows/Python%20package/badge.svg)](https://github.com/IBM/sqlalchemy-ibmi/actions?workflow=Python+package)
 [![Documentation Status](https://readthedocs.org/projects/sqlalchemy-ibmi/badge/?version=latest)](https://sqlalchemy-ibmi.readthedocs.io/en/latest/?badge=latest)
 


### PR DESCRIPTION
The version badge was link to itoolkit instead of sqlalchemy-ibmi. Also, the PyPI link was using the old python.org URL. Since linking both badges to the same location seems redundant, fix the PyPI badge link and remove the link from the version badge.