### PR TITLE
TrimCharFields, Values, System vs system

### DIFF
--- a/samples/Core.py
+++ b/samples/Core.py
@@ -16,7 +16,7 @@ UID = input("UID: ")
 PWD = input("PWD: ")
 extra = input("Add opts: ")
 
-conn_string = "ibmi://{}:{}@{}/?{}".format(system, UID, PWD, extra)
+conn_string = "ibmi://{}:{}@{}/?{}".format(UID, PWD, system, extra)
 
 engine = sa.create_engine( conn_string, echo=True)
 

--- a/samples/ORM.py
+++ b/samples/ORM.py
@@ -17,7 +17,7 @@ UID = input("UID: ")
 PWD = input("PWD: ")
 extra = input("Add opts: ")
 
-conn_string = "ibmi://{}:{}@{}/?{}".format(system, UID, PWD, extra)
+conn_string = "ibmi://{}:{}@{}/?{}".format(UID, PWD, system, extra)
 
 engine = sa.create_engine( conn_string, echo=True)
 

--- a/sqlalchemy_ibmi/base.py
+++ b/sqlalchemy_ibmi/base.py
@@ -642,7 +642,7 @@ class DB2ExecutionContext(default.DefaultExecutionContext):
         if self._select_lastrowid:
             conn._cursor_execute(
                 self.cursor,
-                "SELECT IDENTITY_VAL_LOCAL() FROM SYSIBM.SYSDUMMY1",
+                "VALUES IDENTITY_VAL_LOCAL()",
                 (),
                 self)
             row = self.cursor.fetchall()[0]
@@ -651,9 +651,8 @@ class DB2ExecutionContext(default.DefaultExecutionContext):
 
     def fire_sequence(self, seq, type_):
         return self._execute_scalar(
-            "SELECT NEXTVAL FOR " +
-            self.connection.dialect.identifier_preparer.format_sequence(seq) +
-            " FROM SYSIBM.SYSDUMMY1",
+            "VALUES NEXTVAL FOR " +
+            self.connection.dialect.identifier_preparer.format_sequence(seq),
             type_)
 
 
@@ -846,7 +845,7 @@ class IBMiDb2Dialect(default.DefaultDialect):
     def _get_default_schema_name(self, connection):
         """Return: current setting of the schema attribute"""
         default_schema_name = connection.execute(
-            u'SELECT CURRENT_SCHEMA FROM SYSIBM.SYSDUMMY1').scalar()
+            u'VALUES CURRENT_SCHEMA').scalar()
         if isinstance(default_schema_name, str):
             default_schema_name = default_schema_name.strip()
         return self.normalize_name(default_schema_name)

--- a/sqlalchemy_ibmi/base.py
+++ b/sqlalchemy_ibmi/base.py
@@ -129,7 +129,7 @@ installed, match will take advantage of the CONTAINS function that it provides.
 """
 import datetime
 import re
-from distutils import util
+from distutils import util as du_util
 from sqlalchemy import schema as sa_schema, exc
 from sqlalchemy.sql import compiler
 from sqlalchemy.sql import operators
@@ -800,7 +800,7 @@ class IBMiDb2Dialect(default.DefaultDialect):
                              "IBM i Access ODBC Driver")
 
         try:
-            opts['Naming'] = str(util.strtobool(opts['use_system_naming']))
+            opts['Naming'] = str(du_util.strtobool(opts['use_system_naming']))
         except (ValueError, KeyError):
             opts['Naming'] = '0'
 

--- a/sqlalchemy_ibmi/base.py
+++ b/sqlalchemy_ibmi/base.py
@@ -788,9 +788,9 @@ class IBMiDb2Dialect(default.DefaultDialect):
         return __import__("pyodbc")
 
     def create_connect_args(self, url):
-        opts = url.translate_connect_args(username='user', host='system')
+        opts = url.translate_connect_args(username='user', host='System')
         opts.update(url.query)
-        allowed_opts = {'system', 'user', 'password', 'autocommit', 'readonly',
+        allowed_opts = {'System', 'user', 'password', 'autocommit', 'readonly',
                         'timeout', 'database', 'use_system_naming',
                         'library_list', 'current_schema', 'TrimCharFields'
                         }

--- a/sqlalchemy_ibmi/base.py
+++ b/sqlalchemy_ibmi/base.py
@@ -47,6 +47,7 @@ keyword argument to the create_engine function as a list of strings
 * ``use_system_naming`` - If ``True``, the connection is set to use the System
    naming convention, otherwise it will use the SQL naming convention.
    Defaults to ``False``.
+* ``TrimCharFields`` - If ``1``, all character fields will be returned with trailing spaces truncated.
 
 create-engine arguments:
 
@@ -791,7 +792,7 @@ class IBMiDb2Dialect(default.DefaultDialect):
         opts.update(url.query)
         allowed_opts = {'system', 'user', 'password', 'autocommit', 'readonly',
                         'timeout', 'database', 'use_system_naming',
-                        'library_list', 'current_schema'
+                        'library_list', 'current_schema', 'TrimCharFields'
                         }
 
         if not allowed_opts.issuperset(opts.keys()):


### PR DESCRIPTION
- Added TrimCharFields as a connect argument.  Set to "1" to auto trim trailing spaces on character fields.
- I kept having conflicts on the util import between distutils and sqlalchemy.  I changed the import of distutils' util to be imported as du_util.
- After upgrading to the latest ODBC driver the lower case "system" connect parameter didn't work.  Changed to use "System" and it's working.
- Changed the "SELECT ... FROM SYSIBM.SYSDUMMY1" statements to use the VALUES clause.  The only one that I couldn't do that with is the default_from.
- Changed the sample scripts to have the correct order in the connection string.
