### PR TITLE
Import distutils' util as du_util

### DIFF
--- a/sqlalchemy_ibmi/base.py
+++ b/sqlalchemy_ibmi/base.py
@@ -130,7 +130,7 @@ installed, match will take advantage of the CONTAINS function that it provides.
 """
 import datetime
 import re
-from distutils import util
+from distutils import util as du_util
 from sqlalchemy import schema as sa_schema, exc
 from sqlalchemy.sql import compiler
 from sqlalchemy.sql import operators
@@ -800,7 +800,7 @@ class IBMiDb2Dialect(default.DefaultDialect):
                              "IBM i Access ODBC Driver")
 
         try:
-            opts['Naming'] = str(util.strtobool(opts['use_system_naming']))
+            opts['Naming'] = str(du_util.strtobool(opts['use_system_naming']))
         except KeyError:
             opts['Naming'] = '0'
         except ValueError:
@@ -808,7 +808,7 @@ class IBMiDb2Dialect(default.DefaultDialect):
 
         try:
             trim_char_fields = opts.pop('trim_char_fields')
-            opts['TrimCharFields'] = str(util.strtobool(trim_char_fields))
+            opts['TrimCharFields'] = str(du_util.strtobool(trim_char_fields))
         except KeyError:
             pass
         except ValueError:

--- a/sqlalchemy_ibmi/base.py
+++ b/sqlalchemy_ibmi/base.py
@@ -130,7 +130,7 @@ installed, match will take advantage of the CONTAINS function that it provides.
 """
 import datetime
 import re
-from distutils import util as du_util
+from distutils.util import strtobool
 from sqlalchemy import schema as sa_schema, exc
 from sqlalchemy.sql import compiler
 from sqlalchemy.sql import operators
@@ -800,7 +800,7 @@ class IBMiDb2Dialect(default.DefaultDialect):
                              "IBM i Access ODBC Driver")
 
         try:
-            opts['Naming'] = str(du_util.strtobool(opts['use_system_naming']))
+            opts['Naming'] = str(strtobool(opts['use_system_naming']))
         except KeyError:
             opts['Naming'] = '0'
         except ValueError:
@@ -808,7 +808,7 @@ class IBMiDb2Dialect(default.DefaultDialect):
 
         try:
             trim_char_fields = opts.pop('trim_char_fields')
-            opts['TrimCharFields'] = str(du_util.strtobool(trim_char_fields))
+            opts['TrimCharFields'] = str(strtobool(trim_char_fields))
         except KeyError:
             pass
         except ValueError:


### PR DESCRIPTION
I kept having conflicts with sqlalchemy's util at run time. 

Changed to import distutils util as du_util.  
Changed util.strtobool's to du_util.strtobool.

python app.py
Traceback (most recent call last):
  File "app.py", line 3, in <module>
    from database import db_session
  File "C:\Users\S111059\Desktop\Python\inquiry\database.py", line 12, in <module>
    engine = create_engine(f'{SQLALCHEMY_DATABASE_URL}?current_schema={DEFAULT_SCHEMA}&trim_char_fields=True')
  File "<string>", line 2, in create_engine
  File "C:\Users\S111059\Anaconda3\lib\site-packages\sqlalchemy\util\deprecations.py", line 298, in warned
    return fn(*args, **kwargs)
  File "C:\Users\S111059\Anaconda3\lib\site-packages\sqlalchemy\engine\create.py", line 564, in create_engine
    (cargs, cparams) = dialect.create_connect_args(u)
  File "C:\Users\S111059\Anaconda3\lib\site-packages\sqlalchemy_ibmi\base.py", line 803, in create_connect_args
    opts['Naming'] = str(util.strtobool(opts['use_system_naming']))
AttributeError: module 'sqlalchemy.util' has no attribute 'strtobool'