### PR TITLE
[ISSUE-136]  Updated to allow newer python / pyodbc clients to connect

### DIFF
--- a/sqlalchemy_ibmi/base.py
+++ b/sqlalchemy_ibmi/base.py
@@ -861,7 +861,7 @@ class IBMiDb2Dialect(default.DefaultDialect):
 
         self.map_connect_opts(opts)
 
-        return [["Driver={%s}; UNICODESQL=1; TRUEAUTOCOMMIT=1; XDYNAMIC=0;" % (
+        return [["Driver={%s}; UNICODESQL=1; TRUEAUTOCOMMIT=1; XDYNAMIC=0" % (
                  self.pyodbc_driver_name)], opts]
 
     def is_disconnect(self, e, connection, cursor):


### PR DESCRIPTION
#136 

## Problem?

The trailing `;` in the dsn prevented connections to ibm i from focal
fossa on python 3.8+.

## Solution!

Removed the trailing `;` so that newer clients could connect