### PR TITLE
Added support for [`lob_threshold_kb`](https://github.com/IBM/sqlalch…

### DIFF
--- a/sqlalchemy_ibmi/base.py
+++ b/sqlalchemy_ibmi/base.py
@@ -807,6 +807,7 @@ class IBMiDb2Dialect(default.DefaultDialect):
         'database': ('DATABASE', str, None),
         'use_system_naming': ('NAM', to_bool, False),
         'trim_char_fields': ('TRIMCHAR', to_bool, None),
+        'lob_threshold_kb': ('maxfieldlen', str, None),
     }
 
     DRIVER_KEYWORDS_SPECIAL = {'current_schema', 'library_list'}


### PR DESCRIPTION
…emy-ibmi/issues/137)

#137 

Added support for log_threshold_kb as a connection string parameter.  This commit will translate the query param to the appropriate expected odbc setting.